### PR TITLE
Optional customer_id for create/purchase basket

### DIFF
--- a/softix/customers.py
+++ b/softix/customers.py
@@ -1,0 +1,3 @@
+class Customer(object):
+    def __init__(self, customer_data):
+        self.customer_data = customer_data

--- a/softix/helpers.py
+++ b/softix/helpers.py
@@ -1,0 +1,6 @@
+def remove_none(data):
+    if not data:
+        return
+    for k, v in data.items():
+        if v is None:
+            del(data[k])

--- a/softix/payments.py
+++ b/softix/payments.py
@@ -1,0 +1,25 @@
+class Payment(object):
+    def __init__(self, amount, means_of_payment='EXTERNAL'):
+        self.amount = amount
+        self.means_of_payment = means_of_payment
+
+    def to_request(self):
+        request = {
+            'Amount': self.amount,
+            'MeansOfPayment': self.means_of_payment
+        }
+        return request
+
+
+class Fee(object):
+
+    def __init__(self, fee_type, code):
+        self.type = fee_type
+        self.code = code
+
+    def to_request(self):
+        fee = {
+            'Type': self.type,
+            'Code': self.code,
+        }
+        return fee

--- a/softix/sessions.py
+++ b/softix/sessions.py
@@ -3,9 +3,8 @@ import requests
 
 class Session(requests.sessions.Session):
 
-
     def __init__(self):
-        super(Session, self).__init__() 
+        super(Session, self).__init__()
         self.base_url = 'https://api.etixdubai.com/'
 
         headers = {

--- a/tests/cassettes/SoftixCore_purchase_basket.json
+++ b/tests/cassettes/SoftixCore_purchase_basket.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-11-16T05:06:10",
+      "recorded_at": "2016-11-20T22:15:53",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,18 +17,18 @@
           "User-Agent": "python-requests/2.10.0"
         },
         "method": "GET",
-        "uri": "https://api.etixdubai.com/baskets/2587-34722766?sellerCode=ANMFZ1"
+        "uri": "https://api.etixdubai.com/baskets/4281-35183081?sellerCode=ANMFZ1"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"Expiry\":null,\"Id\":\"2587-34722766\",\"Offers\":[{\"Id\":\"1\",\"InventorySource\":{\"Id\":\"2587:34722766\",\"Name\":\"Origin\"},\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":\"1\",\"PriceCategoryCode\":\"1\",\"PriceCategory\":null,\"Seller\":null,\"Channel\":null,\"Demand\":[{\"PriceTypeId\":null,\"PriceTypeCode\":\"G\",\"PriceType\":null,\"Quantity\":3,\"Admits\":3,\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Customer\":null,\"Prices\":[{\"Id\":null,\"SheetId\":0,\"Net\":54000,\"Fees\":[{\"Id\":null,\"Bucket\":null,\"Code\":null,\"FinanceCode\":null,\"Inside\":false,\"Name\":null,\"SheetId\":0,\"Total\":0,\"Type\":\"1\",\"TypeName\":\"BookingFee\"}]}]},{\"PriceTypeId\":null,\"PriceTypeCode\":\"Q\",\"PriceType\":null,\"Quantity\":3,\"Admits\":3,\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Customer\":null,\"Prices\":null}],\"Seats\":[{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"-\",\"RzStr\":\"RGA/G139-141,Q142-144\"}],\"Fees\":[{\"Id\":null,\"Bucket\":null,\"Code\":\"W\",\"FinanceCode\":null,\"Inside\":false,\"Name\":null,\"SheetId\":0,\"Total\":0,\"Type\":\"5\",\"TypeName\":\"Handling Fee\"}]}],\"Fees\":null}"
+          "string": "{\"Expiry\":null,\"Id\":\"4281-35183081\",\"Offers\":[{\"Id\":\"1\",\"InventorySource\":{\"Id\":\"4281:35183081\",\"Name\":\"Origin\"},\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":\"1\",\"PriceCategoryCode\":\"1\",\"PriceCategory\":null,\"Seller\":null,\"Channel\":null,\"Demand\":[{\"PriceTypeId\":null,\"PriceTypeCode\":\"G\",\"PriceType\":null,\"Quantity\":3,\"Admits\":3,\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Customer\":null,\"Prices\":[{\"Id\":null,\"SheetId\":0,\"Net\":54000,\"Fees\":[{\"Id\":null,\"Bucket\":null,\"Code\":null,\"FinanceCode\":null,\"Inside\":false,\"Name\":null,\"SheetId\":0,\"Total\":0,\"Type\":\"1\",\"TypeName\":\"BookingFee\"}]}]},{\"PriceTypeId\":null,\"PriceTypeCode\":\"Q\",\"PriceType\":null,\"Quantity\":3,\"Admits\":3,\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Customer\":null,\"Prices\":null}],\"Seats\":[{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"-\",\"RzStr\":\"RGA/G186-188,Q189-191\"}],\"Fees\":[{\"Id\":null,\"Bucket\":null,\"Code\":\"W\",\"FinanceCode\":null,\"Inside\":false,\"Name\":null,\"SheetId\":0,\"Total\":0,\"Type\":\"5\",\"TypeName\":\"Handling Fee\"}]}],\"Fees\":null}"
         },
         "headers": {
           "Cache-Control": "no-cache",
           "Content-Length": "1056",
           "Content-Type": "application/json; charset=utf-8",
-          "Date": "Wed, 16 Nov 2016 05:03:30 GMT",
+          "Date": "Sun, 20 Nov 2016 22:13:11 GMT",
           "Expires": "-1",
           "Pragma": "no-cache",
           "Server": "Microsoft-IIS/7.5",
@@ -39,11 +39,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.etixdubai.com/baskets/2587-34722766?sellerCode=ANMFZ1"
+        "url": "https://api.etixdubai.com/baskets/4281-35183081?sellerCode=ANMFZ1"
       }
     },
     {
-      "recorded_at": "2016-11-16T05:06:10",
+      "recorded_at": "2016-11-20T22:15:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -60,18 +60,18 @@
           "User-Agent": "python-requests/2.10.0"
         },
         "method": "POST",
-        "uri": "https://api.etixdubai.com/Baskets/2587-34722766/purchase"
+        "uri": "https://api.etixdubai.com/Baskets/4281-35183081/purchase"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"OrderId\":\"20161116,1023\"}"
+          "string": "{\"OrderId\":\"20161121,152\"}"
         },
         "headers": {
           "Cache-Control": "no-cache",
-          "Content-Length": "27",
+          "Content-Length": "26",
           "Content-Type": "application/json; charset=utf-8",
-          "Date": "Wed, 16 Nov 2016 05:03:31 GMT",
+          "Date": "Sun, 20 Nov 2016 22:13:12 GMT",
           "Expires": "-1",
           "Pragma": "no-cache",
           "Server": "Microsoft-IIS/7.5",
@@ -82,7 +82,7 @@
           "code": 201,
           "message": "Created"
         },
-        "url": "https://api.etixdubai.com/Baskets/2587-34722766/purchase"
+        "url": "https://api.etixdubai.com/Baskets/4281-35183081/purchase"
       }
     }
   ],

--- a/tests/cassettes/SoftixCore_reverse_order.json
+++ b/tests/cassettes/SoftixCore_reverse_order.json
@@ -1,0 +1,88 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-11-16T05:31:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.softix.api-v1.0+json",
+          "Accept-Encoding": "gzip, deflate",
+          "Accept-Language": "en_US",
+          "Authorization": "Bearer <OAUTH_TOKEN>>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "python-requests/2.10.0"
+        },
+        "method": "GET",
+        "uri": "https://api.etixdubai.com/orders/20161116,1023?sellerCode=ANMFZ1"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"Id\":\"20161116,1023\",\"DateTime\":\"0001-01-01T00:00:00\",\"Payments\":[{\"Id\":\"20161116,1022\",\"InventorySource\":{\"Id\":\"20161116,1022\",\"Name\":\"Origin\"}}],\"OrderItems\":[{\"Id\":\"20161116,1023\",\"DateTime\":\"0001-01-01T00:00:00\",\"InventorySource\":{\"Id\":\"20161116,1023\",\"Name\":\"Origin\"},\"OrderLineItems\":[{\"Id\":1,\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":null,\"PriceCategoryCode\":\"1\",\"PriceCategoryName\":null,\"Seller\":\"ANMFZ1\",\"Channel\":\"W\",\"PriceTypeId\":null,\"PriceTypeCode\":\"G\",\"PriceTypeName\":\"10DIS\",\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Concession\":false,\"Barcode\":\"29263242296862\",\"Customer\":{\"Id\":null,\"AFile\":\"tel\",\"Account\":\"101\",\"OrgCustomerId\":null},\"Price\":{\"Id\":null,\"SheetId\":0,\"Net\":8000,\"Fees\":[{\"Id\":null,\"Code\":null,\"SheetId\":0,\"Type\":\"4\",\"TypeName\":\"Booking Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null}]},\"Seat\":{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"139\",\"RzStr\":\"RGA/G139-\"}},{\"Id\":2,\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":null,\"PriceCategoryCode\":\"1\",\"PriceCategoryName\":null,\"Seller\":\"ANMFZ1\",\"Channel\":\"W\",\"PriceTypeId\":null,\"PriceTypeCode\":\"G\",\"PriceTypeName\":\"10DIS\",\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Concession\":false,\"Barcode\":\"29224696225352\",\"Customer\":{\"Id\":null,\"AFile\":\"tel\",\"Account\":\"101\",\"OrgCustomerId\":null},\"Price\":{\"Id\":null,\"SheetId\":0,\"Net\":8000,\"Fees\":[{\"Id\":null,\"Code\":null,\"SheetId\":0,\"Type\":\"4\",\"TypeName\":\"Booking Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null}]},\"Seat\":{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"140\",\"RzStr\":\"RGA/G140-\"}},{\"Id\":3,\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":null,\"PriceCategoryCode\":\"1\",\"PriceCategoryName\":null,\"Seller\":\"ANMFZ1\",\"Channel\":\"W\",\"PriceTypeId\":null,\"PriceTypeCode\":\"G\",\"PriceTypeName\":\"10DIS\",\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Concession\":false,\"Barcode\":\"29222623648289\",\"Customer\":{\"Id\":null,\"AFile\":\"tel\",\"Account\":\"101\",\"OrgCustomerId\":null},\"Price\":{\"Id\":null,\"SheetId\":0,\"Net\":8000,\"Fees\":[{\"Id\":null,\"Code\":null,\"SheetId\":0,\"Type\":\"4\",\"TypeName\":\"Booking Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null}]},\"Seat\":{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"141\",\"RzStr\":\"RGA/G141-\"}},{\"Id\":4,\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":null,\"PriceCategoryCode\":\"1\",\"PriceCategoryName\":null,\"Seller\":\"ANMFZ1\",\"Channel\":\"W\",\"PriceTypeId\":null,\"PriceTypeCode\":\"Q\",\"PriceTypeName\":\"NMFZCO\",\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Concession\":false,\"Barcode\":\"29966228922324\",\"Customer\":{\"Id\":null,\"AFile\":\"tel\",\"Account\":\"101\",\"OrgCustomerId\":null},\"Price\":{\"Id\":null,\"SheetId\":0,\"Net\":10000,\"Fees\":[{\"Id\":null,\"Code\":null,\"SheetId\":0,\"Type\":\"4\",\"TypeName\":\"Booking Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null}]},\"Seat\":{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"142\",\"RzStr\":\"RGA/Q142-\"}},{\"Id\":5,\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":null,\"PriceCategoryCode\":\"1\",\"PriceCategoryName\":null,\"Seller\":\"ANMFZ1\",\"Channel\":\"W\",\"PriceTypeId\":null,\"PriceTypeCode\":\"Q\",\"PriceTypeName\":\"NMFZCO\",\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Concession\":false,\"Barcode\":\"29956639222294\",\"Customer\":{\"Id\":null,\"AFile\":\"tel\",\"Account\":\"101\",\"OrgCustomerId\":null},\"Price\":{\"Id\":null,\"SheetId\":0,\"Net\":10000,\"Fees\":[{\"Id\":null,\"Code\":null,\"SheetId\":0,\"Type\":\"4\",\"TypeName\":\"Booking Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null}]},\"Seat\":{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"143\",\"RzStr\":\"RGA/Q143-\"}},{\"Id\":6,\"DateTime\":\"0001-01-01T00:00:00\",\"PerformanceCode\":\"ETES0000004EL\",\"PriceCategoryId\":null,\"PriceCategoryCode\":\"1\",\"PriceCategoryName\":null,\"Seller\":\"ANMFZ1\",\"Channel\":\"W\",\"PriceTypeId\":null,\"PriceTypeCode\":\"Q\",\"PriceTypeName\":\"NMFZCO\",\"OfferCode\":null,\"QualifierCode\":null,\"Entitlement\":null,\"Concession\":false,\"Barcode\":\"29942266283239\",\"Customer\":{\"Id\":null,\"AFile\":\"tel\",\"Account\":\"101\",\"OrgCustomerId\":null},\"Price\":{\"Id\":null,\"SheetId\":0,\"Net\":10000,\"Fees\":[{\"Id\":null,\"Code\":null,\"SheetId\":0,\"Type\":\"4\",\"TypeName\":\"Booking Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null}]},\"Seat\":{\"Section\":\"SGA\",\"Row\":\"GA\",\"Seats\":\"144\",\"RzStr\":\"RGA/Q144-\"}}],\"Fees\":[{\"Id\":null,\"Code\":\"W\",\"SheetId\":0,\"Type\":\"5\",\"TypeName\":\"Handling Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null},{\"Id\":null,\"Code\":null,\"SheetId\":0,\"Type\":\"4\",\"TypeName\":\"Paytype Fee\",\"Name\":null,\"Total\":0,\"Bucket\":null,\"Inside\":false,\"FinanceCode\":null}]}]}"
+        },
+        "headers": {
+          "Cache-Control": "no-cache",
+          "Content-Length": "4698",
+          "Content-Type": "application/json; charset=utf-8",
+          "Date": "Wed, 16 Nov 2016 05:28:42 GMT",
+          "Expires": "-1",
+          "Pragma": "no-cache",
+          "Server": "Microsoft-IIS/7.5",
+          "X-AspNet-Version": "4.0.30319",
+          "X-Powered-By": "ASP.NET"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.etixdubai.com/orders/20161116,1023?sellerCode=ANMFZ1"
+      }
+    },
+    {
+      "recorded_at": "2016-11-16T05:31:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"refunds\": [{\"Amount\": 54000, \"MeansOfPayment\": \"EXTERNAL\"}], \"Seller\": \"ANMFZ1\"}"
+        },
+        "headers": {
+          "Accept": "application/vnd.softix.api-v1.0+json",
+          "Accept-Encoding": "gzip, deflate",
+          "Accept-Language": "en_US",
+          "Authorization": "Bearer <OAUTH_TOKEN>>",
+          "Connection": "keep-alive",
+          "Content-Length": "82",
+          "Content-Type": "application/json",
+          "User-Agent": "python-requests/2.10.0"
+        },
+        "method": "POST",
+        "uri": "https://api.etixdubai.com/orders/20161116,1023/reverse"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": "no-cache",
+          "Date": "Wed, 16 Nov 2016 05:28:42 GMT",
+          "Expires": "-1",
+          "Pragma": "no-cache",
+          "Server": "Microsoft-IIS/7.5",
+          "X-AspNet-Version": "4.0.30319",
+          "X-Powered-By": "ASP.NET"
+        },
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "url": "https://api.etixdubai.com/orders/20161116,1023/reverse"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.7.2"
+}

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -93,9 +93,21 @@ def test_purchase_basket(seller_code):
     st.access_token = os.environ.get('SOFTIX_TOKEN', '')
 
     with recorder.use_cassette(cassette_name, match_requests_on=match_on):
-        order = st.purchase_basket(seller_code, '2587-34722766')
+        order = st.purchase_basket(seller_code, '4281-35183081')
         assert order
         assert isinstance(order, dict)
+
+
+def test_reverse_order(seller_code):
+    st = softix.SoftixCore()
+    recorder = betamax.Betamax(st.session)
+    cassette_name = 'SoftixCore_reverse_order'
+    match_on = ['uri', 'method', 'json-body']
+    st.access_token = os.environ.get('SOFTIX_TOKEN', '')
+
+    with recorder.use_cassette(cassette_name, match_requests_on=match_on):
+        order = st.reverse_order(seller_code, '20161116,1023')
+        assert order is None
 
 
 def test_view_order(seller_code):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -20,6 +20,14 @@ def test_authenticate(softixcore):
         headers=None
     )
 
+def test_customer():
+    """
+    Verify customer object.
+    """
+    customer = softix.models.Customer({})
+    assert customer.to_request() == {}
+
+
 def test_order(softixcore, auth_headers):
     """
     Verify the URL called.


### PR DESCRIPTION
Add reverse_order integration test

Per Akram's e-mail, the purchase basket call lacks customer information. Therefore, we will support an optional customer_id, instead of mandatory (for backwards compatibility).